### PR TITLE
Impersonating gsuite user if needed; fixes Drive storage quota exceeded

### DIFF
--- a/qa_python_utils/google/server_credentials.py
+++ b/qa_python_utils/google/server_credentials.py
@@ -26,6 +26,8 @@ except Exception:
     if CREDENTIALS_JSON is None:
         CREDENTIALS_JSON = os.getenv('QA_PYTHON_UTILS_CREDENTIALS_JSON', os.getenv('CREDENTIALS_JSON'))
 
+IMPERSONATED_USER_EMAIL = os.getenv('QA_PYTHON_UTILS_IMPERSONATED_USER_EMAIL', os.getenv('IMPERSONATED_USER_EMAIL'))
+
 log.info("Using CREDENTIALS_JSON: {}".format(CREDENTIALS_JSON))
 
 
@@ -36,4 +38,8 @@ def get_credentials():
     credentials = (ServiceAccountCredentials.
                    from_json_keyfile_dict(json.loads(CREDENTIALS_JSON),
                                           SCOPES))
+
+    if IMPERSONATED_USER_EMAIL:
+        credentials = credentials.create_delegated(IMPERSONATED_USER_EMAIL)
+
     return credentials


### PR DESCRIPTION
To allow a service account to impersonate a gsuite user, please follow: https://developers.google.com/admin-sdk/directory/v1/guides/delegation

