### PR TITLE
[DS-179] Creating upsert_partition method for N partitions

### DIFF
--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -319,7 +319,7 @@ class AthenaClient(object):
         self.execute_query_and_wait_for_results("""MSCK REPAIR TABLE {}.{}""".format(database, table_name))
 
     @logger
-    def upsert_partition(self, bucket_folder_path, database, table, partition_name_list, partition_value_list):
+    def upsert_partitions(self, bucket_folder_path, database, table, partition_name_list, partition_value_list):
         partition_list = []
 
         for partition_name, partition_value in zip(partition_name_list, partition_value_list):

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -318,10 +318,8 @@ class AthenaClient(object):
     def msck_repair_table(self, database, table_name):
         self.execute_query_and_wait_for_results("""MSCK REPAIR TABLE {}.{}""".format(database, table_name))
 
+    @logger(exclude=['partitions_list_dicts'])
     def upsert_partitions(self, bucket_folder_path, database, table, partitions_list_dicts):
-        logger.info(
-            'm=upsert_partitions, msg=Method to create multiple partitions within a table'
-            'run add_partition function.')
 
         partition_list = []
 
@@ -342,7 +340,6 @@ class AthenaClient(object):
                     LOCATION 's3://{3}'""".format(database, table, ','.join(partition_list), bucket_folder_path)
 
             logger.info('m=upsert_partition, statement: \n{}'.format(add_stmt))
-
             self.execute_query_and_wait_for_results(sql=add_stmt)
 
         except Exception:

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -346,7 +346,7 @@ class AthenaClient(object):
                       ADD IF NOT EXISTS PARTITION ({2})
                       LOCATION 's3://{3}'""".format(database, table, ','.join(partition_list), bucket_folder_path)
 
-        logger.info('m=upsert_partition, running this command: \n{}'.format(add_stmt))
+        logger.info('m=upsert_partition, statement=\n{}'.format(add_stmt))
         self.execute_query_and_wait_for_results(sql=add_stmt)
 
     @logger

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -291,8 +291,7 @@ class AthenaClient(object):
                                    partitions=partitions, serde='org.openx.data.jsonserde.JsonSerDe',
                                    serde_options=serde_options, drop_if_exists=drop_if_exists)
 
-    def __create_athena_table(self, database, table_name, schema, location, serde, partitions=None,
-                              serde_options=None, drop_if_exists=True):
+    def __create_athena_table(self, database, table_name, schema, location, serde, partitions=None, serde_options=None, drop_if_exists=True):
         if drop_if_exists:
             self.execute_query_and_wait_for_results("""DROP TABLE IF EXISTS {}.{}""".format(database, table_name))
 
@@ -318,18 +317,18 @@ class AthenaClient(object):
 
     def msck_repair_table(self, database, table_name):
         self.execute_query_and_wait_for_results("""MSCK REPAIR TABLE {}.{}""".format(database, table_name))
-    
-    @logger 
+
+    @logger
     def upsert_partition(self, bucket_folder_path, database, table, partition_name_list, partition_value_list):
         partition_list = []
 
         for partition_name, partition_value in zip(partition_name_list, partition_value_list):
             # create list of partitions
-            partition_list.append("{0}='{1}'".format(partition_name, 
+            partition_list.append("{0}='{1}'".format(partition_name,
                                                      partition_value))
             # add path for each partition
             bucket_folder_path += '/{0}={1}'.format(partition_name, partition_value)
-        
+
         drop_stmt = """ALTER TABLE {0}.{1}
                         DROP IF EXISTS PARTITION ({2})""".format(database, table, ','.join(partition_list))
 
@@ -338,11 +337,11 @@ class AthenaClient(object):
         except Exception:
             logger.warn('m=upsert_partition, bucket_folder_path={}, database={}, table={}, partition_name={}, '
                         'partition_value={}, msg=exception raised while deleting partition'.format(bucket_folder_path,
-                                                                                                   database, 
+                                                                                                   database,
                                                                                                    table,
                                                                                                    ','.join(partition_name_list),
                                                                                                    ','.join(partition_value_list)))
-        
+
         add_stmt = """ALTER TABLE {0}.{1}
                       ADD IF NOT EXISTS PARTITION ({2})
                       LOCATION 's3://{3}'""".format(database, table, ','.join(partition_list), bucket_folder_path)

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -318,14 +318,14 @@ class AthenaClient(object):
     def msck_repair_table(self, database, table_name):
         self.execute_query_and_wait_for_results("""MSCK REPAIR TABLE {}.{}""".format(database, table_name))
 
-    def upsert_partitions(self, bucket_folder_path, database, table, partitions_list_dict):
+    def upsert_partitions(self, bucket_folder_path, database, table, partitions_list_dicts):
         logger.info(
             'm=upsert_partitions, msg=Method to create multiple partitions within a table'
             'run add_partition function.')
 
         partition_list = []
         
-        for partition in partitions_list_dict:
+        for partition in partitions_list_dicts:
             # create list of partitions
             partition_list.append("{0}='{1}'".format(partition['partition_name'], partition['partition_value']))
             # add path for each partition

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -1,7 +1,7 @@
 import re
 import sys
 import time
-
+import json
 import boto3
 import botocore
 import fastparquet as fp
@@ -318,8 +318,10 @@ class AthenaClient(object):
     def msck_repair_table(self, database, table_name):
         self.execute_query_and_wait_for_results("""MSCK REPAIR TABLE {}.{}""".format(database, table_name))
 
-    @logger(exclude=['partitions_list_dicts'])
     def upsert_partitions(self, bucket_folder_path, database, table, partitions_list_dicts):
+
+        logger.info('m=upsert_partitions, bucket_folder_path={}, database={}, table={}, partitions_list_dicts=({})'
+                    .format(bucket_folder_path, database, table, json.dumps(partitions_list_dicts)))
 
         partition_list = []
 
@@ -339,7 +341,7 @@ class AthenaClient(object):
                     ADD IF NOT EXISTS PARTITION ({2})
                     LOCATION 's3://{3}'""".format(database, table, ','.join(partition_list), bucket_folder_path)
 
-            logger.info('m=upsert_partition, statement: \n{}'.format(add_stmt))
+            logger.info('m=upsert_partitions, statement: \n{}'.format(add_stmt))
             self.execute_query_and_wait_for_results(sql=add_stmt)
 
         except Exception:


### PR DESCRIPTION
### Why?
In the context of Asterisk, the Events table needs two partitions: execution_date and event. But, in AthenaClient class there is no method that supports this requirement.

### What?
I created upsert_partition method that receives two lists: one list of partition names and one list of partition values and manipulates them to create the correct command to execute in Athena.

### How everything was tested?
- [X] _Replaced import with my local Athena class_
- [X] _Ran local Airflow_
- [X] _Checked if the partitions were created correctly_


### !Attention Points!
_Maybe, this method can replace the upsert_single_partition method in the future. For this, I need test for lists of one value_
