### PR TITLE
[DE-444] Reduce row group offset when creating parquet on AthenaClient

### DIFF
--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -281,7 +281,8 @@ class AthenaClient(object):
     def __save_df_file_into_s3_as_parquet(self, df, bucket, file_path):
         logger.info('m=__save_df_file_into_s3_as_parquet')
         s3_fs = s3fs.S3FileSystem()
-        fp.write('{}/{}'.format(bucket, file_path), df.where(df.notnull(), None), open_with=s3_fs.open)
+        fp.write('{}/{}'.format(bucket, file_path), df.where(df.notnull(), None),
+                 open_with=s3_fs.open, row_group_offsets=500000)
 
         logger.info('m=__save_df_file_into_s3_as_parquet, msg={} ready!'.format(file_path))
 


### PR DESCRIPTION
A DAG in the bi-etl-ejuice project (`bi-crm-load`) is failing because of trying to save a huge dataframe with the AthenaClient.
This PR reduces the default value of the param `row_group_offsets` from 50000000 to 500000.
The stack trace of the error follows: 
```
[2020-01-09 13:37:03,245] {base_task_runner.py:101} INFO - Job 4686600: Subtask move_tasks_resolution_to_clean IOError: Overflow error while writing page; try using a smaller value for `row_group_offsets`. Original message: int out of range
[2020-01-09 13:37:07,171] {logging_mixin.py:95} INFO - [2020-01-09 13:37:07,171] {jobs.py:2527} INFO - Task exited with return code 1
```  