### PR TITLE
[DE-731] Refactoring AthenaClient to receive aws_access_key_id and aws_secret_access_key as parameters

### DIFF
--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -399,7 +399,7 @@ class AthenaClient(object):
             table_name,
             partition
         )
-        AthenaClient(self.s3_bucket).execute_raw_query(sql=sql)
+        self.execute_raw_query(sql=sql)
 
     def update_partitions(self, table, location):
         # An alternative approach would be to simply use an

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -23,14 +23,14 @@ logger = QuintoAndarLogger('aws.athena')
 
 class AthenaClient(object):
     @logger(exclude=["aws_access_key_id", "aws_secret_access_key"])
-    def __init__(self, s3_bucket=None, bucket_folder_path='query_results', aws_access_key_id=None,
-                 aws_secret_access_key=None):
+    def __init__(self, s3_bucket=None, aws_access_key_id=None, aws_secret_access_key=None,
+                 bucket_folder_path='query_results'):
         self.s3_bucket = s3_bucket
 
         if aws_access_key_id is not None and aws_secret_access_key is not None:
             self.athena_client = boto3.client('athena', aws_access_key_id=aws_access_key_id,
                                               aws_secret_access_key=aws_secret_access_key)
-            self.s3_resource = boto3.resource('s3', aws_access_key_id=aws_secret_access_key,
+            self.s3_resource = boto3.resource('s3', aws_access_key_id=aws_access_key_id,
                                               aws_secret_access_key=aws_secret_access_key)
         else:
             self.athena_client = boto3.client('athena')

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -26,8 +26,9 @@ class AthenaClient(object):
     def __init__(self, s3_bucket=None, aws_access_key_id=None, aws_secret_access_key=None,
                  bucket_folder_path='query_results'):
         self.s3_bucket = s3_bucket
-
-        if aws_access_key_id is not None and aws_secret_access_key is not None:
+        self.aws_access_key_id = aws_access_key_id
+        self.aws_secret_access_key = aws_secret_access_key
+        if self.aws_access_key_id is not None and self.aws_secret_access_key is not None:
             self.athena_client = boto3.client('athena', aws_access_key_id=aws_access_key_id,
                                               aws_secret_access_key=aws_secret_access_key)
             self.s3_resource = boto3.resource('s3', aws_access_key_id=aws_access_key_id,
@@ -289,7 +290,10 @@ class AthenaClient(object):
 
     def __save_df_file_into_s3_as_parquet(self, df, bucket, file_path):
         logger.info('m=__save_df_file_into_s3_as_parquet')
-        s3_fs = s3fs.S3FileSystem()
+        if self.aws_access_key_id is not None and self.aws_secret_access_key is not None:
+            s3_fs = s3fs.S3FileSystem(key=self.aws_access_key_id, secret=self.aws_secret_access_key)
+        else:
+            s3_fs = s3fs.S3FileSystem()
         fp.write('{}/{}'.format(bucket, file_path), df.where(df.notnull(), None),
                  open_with=s3_fs.open, row_group_offsets=500000)
 

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -23,9 +23,16 @@ logger = QuintoAndarLogger('aws.athena')
 
 class AthenaClient(object):
     @logger
-    def __init__(self, s3_bucket=None, bucket_folder_path='query_results'):
+    def __init__(self, s3_bucket=None, bucket_folder_path='query_results', aws_access_key_id=None,
+                 aws_secret_access_key=None):
         self.s3_bucket = s3_bucket
-        self.athena_client = boto3.client('athena')
+
+        if aws_access_key_id is not None and aws_secret_access_key is not None:
+            self.athena_client = boto3.client('athena', aws_access_key_id=aws_access_key_id,
+                                              aws_secret_access_key=aws_secret_access_key)
+        else:
+            self.athena_client = boto3.client('athena')
+
         self.s3_resource = boto3.resource('s3')
         self.bucket_folder_path = bucket_folder_path
 

--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -22,7 +22,7 @@ logger = QuintoAndarLogger('aws.athena')
 
 
 class AthenaClient(object):
-    @logger
+    @logger(exclude=["aws_access_key_id", "aws_secret_access_key"])
     def __init__(self, s3_bucket=None, bucket_folder_path='query_results', aws_access_key_id=None,
                  aws_secret_access_key=None):
         self.s3_bucket = s3_bucket
@@ -30,10 +30,12 @@ class AthenaClient(object):
         if aws_access_key_id is not None and aws_secret_access_key is not None:
             self.athena_client = boto3.client('athena', aws_access_key_id=aws_access_key_id,
                                               aws_secret_access_key=aws_secret_access_key)
+            self.s3_resource = boto3.resource('s3', aws_access_key_id=aws_secret_access_key,
+                                              aws_secret_access_key=aws_secret_access_key)
         else:
             self.athena_client = boto3.client('athena')
+            self.s3_resource = boto3.resource('s3')
 
-        self.s3_resource = boto3.resource('s3')
         self.bucket_folder_path = bucket_folder_path
 
     @logger


### PR DESCRIPTION
Why?
Since we need to split data and product aws accounts, we need to refactor AthenaClient to access Athena in data account from Airflow dags that will continue to run in product account.

What?
Refactor boto client (athena and s3) and s3fs to receive aws_access_key_id and aws_secret_access_key as parameters.

How everything was tested?
Refactoring one dag in Airflow/Athena/S3 forno (with new data forno account) 