### PR TITLE
[DINT-425] Added validation to avoid uploading empty parquet files

### DIFF
--- a/qa_python_utils/aws/athena.py
+++ b/qa_python_utils/aws/athena.py
@@ -254,6 +254,15 @@ class AthenaClient(object):
             s3_bucket=s3_bucket,
             bucket_folder_path=bucket_folder_path
         )
+
+        if df.empty:
+            logger.info(
+                "m=create_parquet_from_query, key={}, msg=Empty dataframe, ending execution".format(
+                    key
+                )
+            )
+            return
+
         self.create_parquet_from_df(key, df, row_group_offsets, raw_columns, clean_columns)
 
     def create_parquet_from_df(self, key, df, row_group_offsets=500000, raw_columns=None,


### PR DESCRIPTION
Added an validation clause to avoid creation of empty parquet files on s3.
Empty parquet files can't have it's schema identified by Redshift Spectrum, causing schema validation errors when using the table, even if it's only one partition.

[Related issue](https://quintoandar.atlassian.net/browse/DINT-425)